### PR TITLE
Add barredUser support

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1250,18 +1250,16 @@ exports.commands = {
 		let barredUsers = Config.barredUsers;
 		let barredIps = Config.barredIps;
 
-		for (let value of barredUsers) {
+		for (const value of barredUsers) {
 			if (value === userid) {
 				return this.errorReply(`That user is barred from public auth.`);
 			}
-			value++;
 		}
 
-		for (let value of barredIps) {
+		for (const value of barredIps) {
 			if (value === targetUser.latestIp) {
 				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
-			value++;
 		}
 
 		if (!room.auth) room.auth = room.chatRoomData.auth = {};
@@ -1314,18 +1312,16 @@ exports.commands = {
 		let barredUsers = Config.barredUsers;
 		let barredIps = Config.barredIps;
 
-		for (let value of barredUsers) {
+		for (const value of barredUsers) {
 			if (value === userid) {
 				return this.errorReply(`That user is barred from public auth.`);
 			}
-			value++;
 		}
 
-		for (let value of barredIps) {
+		for (const value of barredIps) {
 			if (value === targetUser.latestIp) {
 				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
-			value++;
 		}
 
 		let currentGroup = room.getAuth({userid, group: (Users.usergroups[userid] || ' ').charAt(0)});

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1249,27 +1249,19 @@ exports.commands = {
 
 		let barredUsers = Config.barredUsers;
 		let barredIps = Config.barredIps;
-		let n = barredUsers.length;
-		let l = barredIps.length;
-		let i = 0;
 
-		if (n > 0) {
-			while (i < n) {
-				if (userid.includes(barredUsers[i])) {
-					return this.errorReply(`That user is barred from auth on this server.`);
-				}
-				i++;
+		for (let value of barredUsers) {
+			if (value === userid) {
+				return this.errorReply(`That user is barred from public auth.`);
 			}
-			i = 0;
+			value++;
 		}
 
-		if (l > 0) {
-			while (i < l) {
-				if (targetUser.latestIp.includes(barredIps[i])) {
-					return this.errorReply(`The IP that the selected user is on is barred from auth on this server.`);
-				}
-				i++;
+		for (let value of barredIps) {
+			if (value === targetUser.latestIp) {
+				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
+			value++;
 		}
 
 		if (!room.auth) room.auth = room.chatRoomData.auth = {};
@@ -1321,27 +1313,19 @@ exports.commands = {
 
 		let barredUsers = Config.barredUsers;
 		let barredIps = Config.barredIps;
-		let n = barredUsers.length;
-		let l = barredIps.length;
-		let i = 0;
 
-		if (n > 0) {
-			while (i < n) {
-				if (userid.includes(barredUsers[i])) {
-					return this.errorReply(`That user is barred from auth on this server.`);
-				}
-				i++;
+		for (let value of barredUsers) {
+			if (value === userid) {
+				return this.errorReply(`That user is barred from public auth.`);
 			}
-			i = 0;
+			value++;
 		}
 
-		if (l > 0) {
-			while (i < l) {
-				if (targetUser.latestIp.includes(barredIps[i])) {
-					return this.errorReply(`The IP that the selected user is on is barred from auth on this server.`);
-				}
-				i++;
+		for (let value of barredIps) {
+			if (value === targetUser.latestIp) {
+				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
+			value++;
 		}
 
 		let currentGroup = room.getAuth({userid, group: (Users.usergroups[userid] || ' ').charAt(0)});
@@ -2234,27 +2218,19 @@ exports.commands = {
 
 		let barredUsers = Config.barredUsers;
 		let barredIps = Config.barredIps;
-		let n = barredUsers.length;
-		let l = barredIps.length;
-		let i = 0;
 
-		if (n > 0) {
-			while (i < n) {
-				if (userid.includes(barredUsers[i])) {
-					return this.errorReply(`That user is barred from auth on this server.`);
-				}
-				i++;
+		for (let value of barredUsers) {
+			if (value === userid) {
+				return this.errorReply(`That user is barred from public auth.`);
 			}
-			i = 0;
+			value++;
 		}
 
-		if (l > 0) {
-			while (i < l) {
-				if (targetUser.latestIp.includes(barredIps[i])) {
-					return this.errorReply(`The IP that the selected user is on is barred from auth on this server.`);
-				}
-				i++;
+		for (let value of barredIps) {
+			if (value === targetUser.latestIp) {
+				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
+			value++;
 		}
 
 		Users.setOfflineGroup(name, nextGroup);

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1247,6 +1247,31 @@ exports.commands = {
 
 		if (!this.can('makeroom')) return false;
 
+		let barredUsers = Config.barredUsers;
+		let barredIps = Config.barredIps;
+		let n = barredUsers.length;
+		let l = barredIps.length;
+		let i = 0;
+
+		if (n > 0) {
+			while (i < n) {
+				if (userid.includes(barredUsers[i])) {
+					return this.errorReply(`That user is barred from auth on this server.`);
+				}
+				i++;
+			}
+			i = 0;
+		}
+
+		if (l > 0) {
+			while (i < l) {
+				if (targetUser.latestIp.includes(barredIps[i])) {
+					return this.errorReply(`The IP that the selected user is on is barred from auth on this server.`);
+				}
+				i++;
+			}
+		}
+
 		if (!room.auth) room.auth = room.chatRoomData.auth = {};
 
 		room.auth[userid] = '#';
@@ -1292,6 +1317,31 @@ exports.commands = {
 		}
 		if (targetUser && !targetUser.registered) {
 			return this.errorReply(`User '${name}' is unregistered, and so can't be promoted.`);
+		}
+
+		let barredUsers = Config.barredUsers;
+		let barredIps = Config.barredIps;
+		let n = barredUsers.length;
+		let l = barredIps.length;
+		let i = 0;
+
+		if (n > 0) {
+			while (i < n) {
+				if (userid.includes(barredUsers[i])) {
+					return this.errorReply(`That user is barred from auth on this server.`);
+				}
+				i++;
+			}
+			i = 0;
+		}
+
+		if (l > 0) {
+			while (i < l) {
+				if (targetUser.latestIp.includes(barredIps[i])) {
+					return this.errorReply(`The IP that the selected user is on is barred from auth on this server.`);
+				}
+				i++;
+			}
 		}
 
 		let currentGroup = room.getAuth({userid, group: (Users.usergroups[userid] || ' ').charAt(0)});
@@ -2181,6 +2231,32 @@ exports.commands = {
 		if (targetUser && !targetUser.registered) {
 			return this.errorReply(`User '${name}' is unregistered, and so can't be promoted.`);
 		}
+
+		let barredUsers = Config.barredUsers;
+		let barredIps = Config.barredIps;
+		let n = barredUsers.length;
+		let l = barredIps.length;
+		let i = 0;
+
+		if (n > 0) {
+			while (i < n) {
+				if (userid.includes(barredUsers[i])) {
+					return this.errorReply(`That user is barred from auth on this server.`);
+				}
+				i++;
+			}
+			i = 0;
+		}
+
+		if (l > 0) {
+			while (i < l) {
+				if (targetUser.latestIp.includes(barredIps[i])) {
+					return this.errorReply(`The IP that the selected user is on is barred from auth on this server.`);
+				}
+				i++;
+			}
+		}
+
 		Users.setOfflineGroup(name, nextGroup);
 		if (Config.groups[nextGroup].rank < Config.groups[currentGroup].rank) {
 			this.privateModAction(`(${name} was demoted to ${groupName} by ${user.name}.)`);

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -7,6 +7,11 @@ exports.port = 8000;
 //   This should be kept set to 0.0.0.0 unless you know what you're doing.
 exports.bindaddress = '0.0.0.0';
 
+// Barred users/ip who should not have any auth. All users in this will
+//  never be able to be given auth of any kind as long as they are in this array.
+exports.barredUsers = [];
+exports.barredIps = [];
+
 
 // gmcl - Automatically locks the globalmodchat commands.
 exports.gmcl = true;

--- a/ocpu-plugins/ocpu.js
+++ b/ocpu-plugins/ocpu.js
@@ -1161,6 +1161,23 @@ exports.commands = {
 
 		if (!this.can('makeroom')) return false;
 
+		let barredUsers = Config.barredUsers;
+		let barredIps = Config.barredIps;
+
+		for (let value of barredUsers) {
+			if (value === userid) {
+				return this.errorReply(`That user is barred from public auth.`);
+			}
+			value++;
+		}
+
+		for (let value of barredIps) {
+			if (value === targetUser.latestIp) {
+				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
+			}
+			value++;
+		}
+
 		if (!room.auth) room.auth = room.chatRoomData.auth = {};
 
 		room.auth[userid] = '#';

--- a/ocpu-plugins/ocpu.js
+++ b/ocpu-plugins/ocpu.js
@@ -1164,18 +1164,16 @@ exports.commands = {
 		let barredUsers = Config.barredUsers;
 		let barredIps = Config.barredIps;
 
-		for (let value of barredUsers) {
+		for (const value of barredUsers) {
 			if (value === userid) {
 				return this.errorReply(`That user is barred from public auth.`);
 			}
-			value++;
 		}
 
-		for (let value of barredIps) {
+		for (cons5t value of barredIps) {
 			if (value === targetUser.latestIp) {
 				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
-			value++;
 		}
 
 		if (!room.auth) room.auth = room.chatRoomData.auth = {};
@@ -1223,6 +1221,21 @@ exports.commands = {
 
 		if (!user.can('makeroom')) {
 			if (user.userid !== room.founder) return false;
+		}
+
+		let barredUsers = Config.barredUsers;
+		let barredIps = Config.barredIps;
+
+		for (const value of barredUsers) {
+			if (value === userid) {
+				return this.errorReply(`That user is barred from public auth.`);
+			}
+		}
+
+		for (cons5t value of barredIps) {
+			if (value === targetUser.latestIp) {
+				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
+			}
 		}
 
 		if (!room.auth) room.auth = room.chatRoomData.auth = {};

--- a/ocpu-plugins/ocpu.js
+++ b/ocpu-plugins/ocpu.js
@@ -1170,7 +1170,7 @@ exports.commands = {
 			}
 		}
 
-		for (cons5t value of barredIps) {
+		for (const value of barredIps) {
 			if (value === targetUser.latestIp) {
 				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}
@@ -1232,7 +1232,7 @@ exports.commands = {
 			}
 		}
 
-		for (cons5t value of barredIps) {
+		for (const value of barredIps) {
 			if (value === targetUser.latestIp) {
 				return this.errorReply(`The IP that the selected user is on is barred from public auth.`);
 			}


### PR DESCRIPTION
This is so that we can add some barred users and ips from public auth so that someone doesn't accidentally promote that user. This might have some issues, like demoting them after they are put into this array if we forget to. I also don't know if this will stop them from battling, so this will need testing before it's added.

Do not remove the Do-Not-Merge label until someone tests this feature.